### PR TITLE
tech filtering without route stuff

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -22,7 +22,7 @@ angular.module('contribute', [
      * leave it on the server and pull it in with a full AJAX URL.
      */
     $routeProvider
-    .when('/examples/:tech?', {
+    .when('/examples', {
         templateUrl: 'examples.html',
         controller: 'ExamplesController'
     })

--- a/app/static/controllers.js
+++ b/app/static/controllers.js
@@ -72,12 +72,11 @@ var app = angular.module('contribute.controllers', ['ngSanitize'])
 }])
 
 .controller('ExamplesController', [
-    '$scope', '$http', '$routeParams',
-    function($scope, $http, $routeParams) {
+    '$scope', '$http',
+    function($scope, $http) {
         $scope.loading = true;
         document.title = 'Examples of contribute.json';
         $scope.projects = [];
-        var tech = $routeParams.tech;
 
         $http.get('/examples.json')
         .success(function(response) {
@@ -86,9 +85,7 @@ var app = angular.module('contribute.controllers', ['ngSanitize'])
                 $http.get('/load-example?url=' + encodeURIComponent(url))
                 .success(function(response) {
                     if (response.project) {
-                        if (tech === undefined || response.project.keywords.indexOf(tech) !== -1) {
-                            $scope.projects.push(response.project);
-                        }
+                        $scope.projects.push(response.project);
                     } else {
                         console.warn('Failed to get a project for', url);
                     }

--- a/app/static/css/contribute/contribute.less
+++ b/app/static/css/contribute/contribute.less
@@ -41,7 +41,7 @@ input {
   font-size: 1.2rem;
   border-radius: 6px;
 }
-input[type="text"] {
+#validate-url input[type="text"] {
   border: solid 1px #333;
   width: 460px;
 }

--- a/app/static/css/misc.less
+++ b/app/static/css/misc.less
@@ -61,3 +61,6 @@ pre div a.invalid-url {
 .u-padding {
     padding: 10px !important;
 }
+input.filter-by-tag {
+    width: 300px;
+}

--- a/app/templates/partials/examples.html
+++ b/app/templates/partials/examples.html
@@ -1,12 +1,14 @@
 {% include "_banner.html" %}
 
 <section class="wrapper content">
-    <div class='content-column'>
+    <div class="content-column">
       <h1>Examples of Use</h1>
     </div>
 
-    <div class='content-column u-padding'>
-      <input type='text' class='u-padding pull-right' ng-model='searchText.keywords' placeholder='Filter by area of expertise..'/>
+    <div class="content-column u-padding">
+      <input type="text" class="u-padding pull-right filter-by-tag"
+        ng-model="searchText.keywords"
+        placeholder="Filter by tag...">
     </div>
   </div>
 


### PR DESCRIPTION
@koddsson How about this?

A problem with modifying the URL is that if you load `/examples/puppet` and you decide to change "puppet" to "react" you'll end up changing the URL (with pushState) for each keyboard press. A mess.

Once this lands we can consider perhaps using the `location.hash` instead to make the filtering a permalink. 

Also, I change the CSS slightly. The black border and the fixed 460px width was specifically meant for the validation thing on the home page. 
