### PR TITLE
media query small fixes

### DIFF
--- a/app/static/css/contribute/contribute.less
+++ b/app/static/css/contribute/contribute.less
@@ -95,14 +95,14 @@ main {
         line-height: 120%;
         @media all and (max-width: 768px) {
             width: 100%;
-        } 
+        }
     }
     form {
         position: relative;
         width: 60%;
         @media all and (max-width: 768px) {
             width: 100%;
-        } 
+        }
         margin: 25px auto 10px;
         text-align: center;
     }
@@ -118,8 +118,8 @@ main {
         border: 1px solid #333;
         box-shadow: none;
         @media all and (max-width: 768px) {
-            width: 100%;
-        } 
+            width: 95%;
+        }
     }
     input[type="checkbox"] {
         width: 20px;
@@ -191,6 +191,9 @@ main {
     overflow: auto;
     h1 {
         font-size: 48px;
+        @media all and (max-width: 768px) {
+            font-size: 40px;
+        }
     }
 }
 .content-column {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,7 +26,8 @@
                 <nav id="nav-main" role="menubar">
                     <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">Menu</span>
                     <ul role="menu" id="nav-main-menu">
-                        <li role="menuitem" class="first"><a href="/schema">The Schema</a></li>
+                        <li role="menuitem" class="first"><a href="/">Home</a></li>
+                        <li role="menuitem"><a href="/schema">The Schema</a></li>
                         <li role="menuitem"><a href="/examples">Who Uses It?</a></li>
                         <li role="menuitem"><a href="//github.com/mozilla/contribute.json">Fork Us On Github</a></li>
                     </ul>


### PR DESCRIPTION
1. The URL input field looks weird when being 100% as the edges looked cut off
2. The h1 fonts were just waay to big on a mobile screen
3. When in non-mobile view, you can click the mozilla logo in the upper left-hand corner. On mobile you only have the hamburger menu and it lacked a Home option. 
